### PR TITLE
get async api mapping fix

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -234,7 +234,13 @@ module.exports = function (options) {
         },
 
         mapping: function () {
-            return controllersInfo;
+            if (!parsedPromise) {
+                throw new Error('No files were added to ExpressBridge')
+            }
+
+            return parsedPromise.then(function () {
+                return controllersInfo;
+            });
         }
 
     }


### PR DESCRIPTION
Due to async module adding [here](https://github.com/oleksiyk/express-bridge/blob/master/lib/express.js#L174), I had a problem with mapping.
So here is a fix for that.